### PR TITLE
Support assisted injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,4 @@ See more in the [source code](https://github.com/daugeldauge/kinzhal/tree/master
 | Lazy/provider injections | 🚫 | [#2](https://github.com/daugeldauge/kinzhal/issues/2) |
 | `@BindsOptionalOf` | 🚫 |
 | Multibindings | 🚫 | |
-| Assisted injection | 🚫 | |
-
-
+| Assisted injection | ✅ | |

--- a/kinzhal-annotations/src/commonMain/kotlin/com/daugeldauge/kinzhal/annotations/Annotations.kt
+++ b/kinzhal-annotations/src/commonMain/kotlin/com/daugeldauge/kinzhal/annotations/Annotations.kt
@@ -36,3 +36,15 @@ annotation class Scope
 @Retention(AnnotationRetention.SOURCE)
 @Target(AnnotationTarget.ANNOTATION_CLASS)
 annotation class Qualifier
+
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.CONSTRUCTOR)
+annotation class AssistedInject
+
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.VALUE_PARAMETER)
+annotation class Assisted
+
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.CLASS)
+annotation class AssistedFactory

--- a/kinzhal-annotations/src/commonMain/kotlin/com/daugeldauge/kinzhal/annotations/Annotations.kt
+++ b/kinzhal-annotations/src/commonMain/kotlin/com/daugeldauge/kinzhal/annotations/Annotations.kt
@@ -37,14 +37,33 @@ annotation class Scope
 @Target(AnnotationTarget.ANNOTATION_CLASS)
 annotation class Qualifier
 
+/**
+ * Annotates the constructor of a type that will be created via assisted injection.
+ *
+ * Note that an assisted injection type cannot be scoped. In addition, assisted injection
+ * requires the use of a factory annotated with [AssistedFactory].
+ */
 @Retention(AnnotationRetention.SOURCE)
 @Target(AnnotationTarget.CONSTRUCTOR)
 annotation class AssistedInject
 
+/**
+ * Annotates a parameter within an [AssistedInject]-annotated constructor.
+ */
 @Retention(AnnotationRetention.SOURCE)
 @Target(AnnotationTarget.VALUE_PARAMETER)
 annotation class Assisted
 
+/**
+ * Annotates an abstract class or interface used to create an instance of a type via an [AssistedInject] constructor.
+ *
+ * An [AssistedFactory]-annotated type must obey the following constraints:
+ * * The type must be an abstract class or interface,
+ * * The type must contain exactly one abstract, non-default method whose
+ *    * return type must exactly match the type of an assisted injection type, and
+ *    * parameters must match the exact list of [Assisted] parameters in the assisted
+ *          injection type's constructor (and in the same order)
+ */
 @Retention(AnnotationRetention.SOURCE)
 @Target(AnnotationTarget.CLASS)
 annotation class AssistedFactory

--- a/kinzhal-processor/build.gradle.kts
+++ b/kinzhal-processor/build.gradle.kts
@@ -15,6 +15,7 @@ kotlin {
             implementation(projects.kinzhalAnnotations)
             implementation(libs.ksp.symbolProcessingApi)
             implementation(libs.kotlinpoet)
+            implementation(libs.kotlinpoet.ksp)
         }
 
         jvmTest.dependencies {

--- a/kinzhal-processor/src/jvmMain/kotlin/com/daugeldauge/kinzhal/processor/AssistedFactoryDependenciesResolver.kt
+++ b/kinzhal-processor/src/jvmMain/kotlin/com/daugeldauge/kinzhal/processor/AssistedFactoryDependenciesResolver.kt
@@ -1,0 +1,58 @@
+package com.daugeldauge.kinzhal.processor
+
+import com.daugeldauge.kinzhal.annotations.Assisted
+import com.daugeldauge.kinzhal.processor.model.AssistedFactoryType
+import com.daugeldauge.kinzhal.processor.model.Key
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSValueParameter
+
+internal class AssistedFactoryDependency(
+    val name: String,
+    val key: Key,
+    val isAssisted: Boolean,
+    val parameter: KSValueParameter,
+)
+
+internal object AssistedFactoryDependenciesResolver {
+    fun match(
+        sourceDeclaration: KSFunctionDeclaration,
+        assistedFactoryType: AssistedFactoryType,
+    ): List<AssistedFactoryDependency> {
+        val dependencies = sourceDeclaration.parameters.map {
+            val isAssisted = it.isAssisted
+            AssistedFactoryDependency(
+                name = if (isAssisted) {
+                    it.name!!.asString()
+                } else {
+                    "${it.name!!.asString()}Provider"
+                },
+                key = it.type.toKey(it.annotations),
+                isAssisted = isAssisted,
+                parameter = it
+            )
+        }
+
+        val assistedSourceParameters = dependencies
+            .asSequence()
+            .filter(AssistedFactoryDependency::isAssisted)
+            .map { it.name to it.key.type }
+            .toList()
+
+        val assistedFactoryParameters = assistedFactoryType.factoryMethod.parameters
+            .map { it.name?.asString() to it.type.resolve() }
+
+        if (assistedSourceParameters != assistedFactoryParameters) {
+            throw NonRecoverableProcessorException(
+                "Factory method in @AssistedFactory must have assisted parameters by same names, types and in the same order as @AssistedInject constructor",
+                assistedFactoryType.factoryMethod
+            )
+        }
+
+        return dependencies
+    }
+}
+
+private val KSValueParameter.isAssisted: Boolean
+    get() = annotations.any {
+        it.annotationType.resolve().declaration.qualifiedName?.asString() == Assisted::class.requireQualifiedName()
+    }

--- a/kinzhal-processor/src/jvmMain/kotlin/com/daugeldauge/kinzhal/processor/GraphResolver.kt
+++ b/kinzhal-processor/src/jvmMain/kotlin/com/daugeldauge/kinzhal/processor/GraphResolver.kt
@@ -17,7 +17,7 @@ internal fun UnresolvedBindingGraph.resolve(logger: KSPLogger): ResolvedBindingG
         val previous = allBindings.put(binding.key, binding)
 
         if (previous != null) {
-            logger.error("Duplicated binding: ${binding.key} already provided in ${previous.declaration.location}", binding.declaration)
+            logger.error("Duplicated binding: ${binding.key} already provided in ${previous.declaration?.location}", binding.declaration)
         }
     }
 

--- a/kinzhal-processor/src/jvmMain/kotlin/com/daugeldauge/kinzhal/processor/KinzhalSymbolProcessor.kt
+++ b/kinzhal-processor/src/jvmMain/kotlin/com/daugeldauge/kinzhal/processor/KinzhalSymbolProcessor.kt
@@ -67,12 +67,14 @@ internal class KinzhalSymbolProcessor(private val codeGenerator: CodeGenerator, 
                     .filter(KSFunctionDeclaration::isAbstract)
                     .toList()
 
+                if (abstractFunctions.size != 1) {
+                    logger.error("@AssistedFactory type must contain only single abstract method", assistedFactoryDeclaration)
+                    return@mapNotNull null
+                }
+
                 AssistedFactoryType(
                     type = assistedFactoryDeclaration.asType(emptyList()),
-                    factoryMethod = abstractFunctions.getOrNull(0) ?: run {
-                        logger.error("@AssistedFactory type must contain only single abstract method", assistedFactoryDeclaration)
-                        return@mapNotNull null
-                    }
+                    factoryMethod = abstractFunctions[0]
                 )
             }.associateBy { it.factoryMethod.returnType?.resolve()?.declaration?.qualifiedName?.asString() }
 

--- a/kinzhal-processor/src/jvmMain/kotlin/com/daugeldauge/kinzhal/processor/KinzhalSymbolProcessor.kt
+++ b/kinzhal-processor/src/jvmMain/kotlin/com/daugeldauge/kinzhal/processor/KinzhalSymbolProcessor.kt
@@ -1,22 +1,13 @@
 package com.daugeldauge.kinzhal.processor
 
-import com.daugeldauge.kinzhal.annotations.AssistedFactory
-import com.daugeldauge.kinzhal.annotations.AssistedInject
-import com.daugeldauge.kinzhal.annotations.Component
-import com.daugeldauge.kinzhal.annotations.Inject
-import com.daugeldauge.kinzhal.annotations.Qualifier
+import com.daugeldauge.kinzhal.annotations.*
 import com.daugeldauge.kinzhal.processor.generation.*
-import com.daugeldauge.kinzhal.processor.generation.asTypeName
-import com.daugeldauge.kinzhal.processor.generation.capitalized
-import com.daugeldauge.kinzhal.processor.generation.generateComponent
-import com.daugeldauge.kinzhal.processor.generation.generateFactory
 import com.daugeldauge.kinzhal.processor.model.*
 import com.google.devtools.ksp.isAbstract
 import com.google.devtools.ksp.isConstructor
 import com.google.devtools.ksp.processing.*
 import com.google.devtools.ksp.symbol.*
-import com.squareup.kotlinpoet.*
-import java.lang.RuntimeException
+import com.squareup.kotlinpoet.ClassName
 
 // TODO scope validation
 // TODO fix possible conflicts in component provider names
@@ -100,7 +91,11 @@ internal class KinzhalSymbolProcessor(private val codeGenerator: CodeGenerator, 
                     addCreateInstanceCall = { add("%T", injectableKey.asTypeName()) },
                     packageName = assistedFactoryType.type.declaration.packageName.asString(),
                     factoryBaseName = assistedFactoryType.type.declaration.simpleName.asString(),
-                    assistedFactoryType = assistedFactoryType
+                    assistedFactoryType = assistedFactoryType,
+                    dependencies = AssistedFactoryDependenciesResolver.match(
+                        sourceDeclaration = injectable,
+                        assistedFactoryType = assistedFactoryType,
+                    )
                 )
             }
             .toList()

--- a/kinzhal-processor/src/jvmMain/kotlin/com/daugeldauge/kinzhal/processor/generation/AssistedFactoryGenerator.kt
+++ b/kinzhal-processor/src/jvmMain/kotlin/com/daugeldauge/kinzhal/processor/generation/AssistedFactoryGenerator.kt
@@ -1,0 +1,165 @@
+package com.daugeldauge.kinzhal.processor.generation
+
+import com.daugeldauge.kinzhal.annotations.Assisted
+import com.daugeldauge.kinzhal.processor.NonRecoverableProcessorException
+import com.daugeldauge.kinzhal.processor.model.AssistedFactoryType
+import com.daugeldauge.kinzhal.processor.model.FactoryBinding
+import com.daugeldauge.kinzhal.processor.model.Key
+import com.daugeldauge.kinzhal.processor.requireQualifiedName
+import com.daugeldauge.kinzhal.processor.toKey
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSValueParameter
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.LambdaTypeName
+import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.ksp.toTypeName
+import com.squareup.kotlinpoet.withIndent
+
+internal fun generateAssistedFactory(
+    codeGenerator: CodeGenerator,
+    injectableKey: Key,
+    sourceDeclaration: KSFunctionDeclaration,
+    addCreateInstanceCall: CodeBlock.Builder.() -> Unit,
+    packageName: String,
+    factoryBaseName: String,
+    assistedFactoryType: AssistedFactoryType,
+): FactoryBinding {
+    class Dependency(
+        val name: String,
+        val key: Key,
+        val isAssisted: Boolean,
+        val parameter: KSValueParameter,
+    )
+
+    val dependencies = sourceDeclaration.parameters.map {
+        val isAssisted = it.isAssisted
+        Dependency(
+            name = if (isAssisted) {
+                it.name!!.asString()
+            } else {
+                "${it.name!!.asString()}Provider"
+            },
+            key = it.type.toKey(it.annotations),
+            isAssisted = isAssisted,
+            parameter = it
+        )
+    }
+
+    val assistedSourceParameters = dependencies
+        .asSequence()
+        .filter(Dependency::isAssisted)
+        .map { it.name to it.key.type }
+        .toList()
+
+    val assistedFactoryParameters = assistedFactoryType.factoryMethod.parameters
+        .map { it.name?.asString() to it.type.resolve() }
+
+    if (assistedSourceParameters != assistedFactoryParameters) {
+        throw NonRecoverableProcessorException(
+            "Factory method in @AssistedFactory must have assisted parameters by same names, types and in the same order as @AssistedInject constructor",
+            assistedFactoryType.factoryMethod
+        )
+    }
+
+    val providers: List<Pair<String, TypeName>> = dependencies
+        .asSequence()
+        .filterNot { it.isAssisted }
+        .map { dependency ->
+            dependency.name to LambdaTypeName.get(returnType = dependency.key.asTypeName())
+        }
+        .toList()
+
+    val containingFile = sourceDeclaration.containingFile!!
+
+    val implName = factoryBaseName + "_Impl"
+    codeGenerator.newFile(
+        dependenciesAggregating = false,
+        dependencies = arrayOf(containingFile),
+        packageName = packageName,
+        fileName = implName,
+    ) {
+
+        val properties = providers.map { (name, type) ->
+            PropertySpec.builder(
+                name,
+                type,
+                KModifier.PRIVATE,
+            ).initializer(name).build()
+        }
+
+        addType(
+            TypeSpec.classBuilder(implName)
+                .addModifiers(KModifier.INTERNAL)
+                .primaryConstructor(
+                    FunSpec.constructorBuilder()
+                        .addParameters(
+                            providers.map { (name, type) -> ParameterSpec.builder(name, type).build() }
+                        )
+                        .build()
+                )
+                .addSuperinterface(assistedFactoryType.type.toTypeName())
+                .addProperties(properties)
+                .addFunction(
+                    FunSpec.builder(assistedFactoryType.factoryMethod.simpleName.asString())
+                        .returns(injectableKey.asTypeName())
+                        .addModifiers(KModifier.OVERRIDE)
+                        .addParameters(
+                            assistedFactoryType.factoryMethod.parameters
+                                .map {
+                                    ParameterSpec.builder(
+                                        name = it.name!!.asString(),
+                                        type = it.type.resolve().toTypeName()
+                                    ).build()
+                                }
+                        )
+                        .addCode(CodeBlock.builder().apply {
+                            add("return ")
+                            addCreateInstanceCall()
+
+                            if (dependencies.isEmpty()) {
+                                add("()")
+                            } else {
+                                add("(\n")
+                                withIndent {
+                                    dependencies.forEach {
+                                        add("%N", it.name)
+                                        if (!it.isAssisted) {
+                                            add("()")
+                                        }
+                                        add(",\n")
+                                    }
+                                }
+                                add(")")
+                            }
+                        }.build())
+                        .build()
+                )
+                .build()
+        )
+    }
+
+    return generateFactory(
+        codeGenerator = codeGenerator,
+        injectableKey = Key(assistedFactoryType.type),
+        scoped = true,
+        sourceDeclaration = null,
+        parameters = dependencies.asSequence().filterNot(Dependency::isAssisted).map(Dependency::parameter).toList(),
+        containingFile = containingFile,
+        addCreateInstanceCall = { add("%T", ClassName(packageName, implName)) },
+        providersAreTransitive = true,
+        packageName = packageName,
+        factoryBaseName = implName
+    )
+}
+
+private val KSValueParameter.isAssisted: Boolean
+    get() = annotations.any {
+        it.annotationType.resolve().declaration.qualifiedName?.asString() == Assisted::class.requireQualifiedName()
+    }

--- a/kinzhal-processor/src/jvmMain/kotlin/com/daugeldauge/kinzhal/processor/model/AssistedFactoryType.kt
+++ b/kinzhal-processor/src/jvmMain/kotlin/com/daugeldauge/kinzhal/processor/model/AssistedFactoryType.kt
@@ -1,0 +1,9 @@
+package com.daugeldauge.kinzhal.processor.model
+
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSType
+
+internal class AssistedFactoryType(
+    val type: KSType,
+    val factoryMethod: KSFunctionDeclaration,
+)

--- a/kinzhal-processor/src/jvmMain/kotlin/com/daugeldauge/kinzhal/processor/model/Binding.kt
+++ b/kinzhal-processor/src/jvmMain/kotlin/com/daugeldauge/kinzhal/processor/model/Binding.kt
@@ -4,7 +4,7 @@ import com.google.devtools.ksp.symbol.*
 
 internal sealed interface Binding {
     val key: Key
-    val declaration: KSDeclaration
+    val declaration: KSDeclaration?
     val dependencies: List<Key>
         get() = emptyList()
 }
@@ -38,7 +38,7 @@ internal class DelegatedBinding(
 
 internal class FactoryBinding(
     override val key: Key,
-    override val declaration: KSDeclaration,
+    override val declaration: KSDeclaration?,
     override val dependencies: List<Key>,
     val containingFile: KSFile,
     val scoped: Boolean,

--- a/kinzhal-processor/src/jvmTest/kotlin/com/daugeldauge/kinzhal/processor/ProcessorErrorsTest.kt
+++ b/kinzhal-processor/src/jvmTest/kotlin/com/daugeldauge/kinzhal/processor/ProcessorErrorsTest.kt
@@ -221,6 +221,52 @@ internal class ProcessorErrorsTest {
         """.trimIndent()))
     }
 
+    @Test
+    fun `assisted factory is not abstract`() {
+        expectError("@AssistedFactory can be applied only to abstract types", kotlin("source.kt", """
+            import com.daugeldauge.kinzhal.annotations.AssistedFactory
+            
+            @AssistedFactory
+            class AssistedFactory
+        """.trimIndent()))
+    }
+
+    @Test
+    fun `assisted factory has no single abstract method`() {
+        expectError("@AssistedFactory type must contain only single abstract method", kotlin("source.kt", """
+            import com.daugeldauge.kinzhal.annotations.AssistedFactory
+            
+            @AssistedFactory
+            interface AssistedFactory {
+                fun build1(): String
+                fun build2(): String
+            }
+        """.trimIndent()))
+    }
+
+    @Test
+    fun `assisted inject is not applied to constructor`() {
+        expectError("@AssistedInject can't be applied to notConstructor: only constructor injection supported", kotlin("source.kt", """
+            import com.daugeldauge.kinzhal.annotations.AssistedInject
+            
+            @AssistedInject
+            fun notConstructor() = Unit
+        """.trimIndent()))
+    }
+
+    @Test
+    fun `no factory for assisted inject type`() {
+        expectError("@AssistedFactory annotated type doesn't exist for type TypeWithoutFactory", kotlin("source.kt", """
+            import com.daugeldauge.kinzhal.annotations.AssistedInject
+            import com.daugeldauge.kinzhal.annotations.Assisted
+            
+            class TypeWithoutFactory @AssistedInject constructor(
+                @Assisted param1: Int,
+                param2: String
+            )
+        """.trimIndent()))
+    }
+
 
     private fun expectError(message: String, vararg sourceFiles: SourceFile) {
         val result = compile(*sourceFiles)

--- a/kinzhal-processor/src/jvmTest/kotlin/com/daugeldauge/kinzhal/processor/ProcessorErrorsTest.kt
+++ b/kinzhal-processor/src/jvmTest/kotlin/com/daugeldauge/kinzhal/processor/ProcessorErrorsTest.kt
@@ -255,15 +255,35 @@ internal class ProcessorErrorsTest {
     }
 
     @Test
-    fun `no factory for assisted inject type`() {
+    fun `no factory for assisted type`() {
         expectError("@AssistedFactory annotated type doesn't exist for type TypeWithoutFactory", kotlin("source.kt", """
-            import com.daugeldauge.kinzhal.annotations.AssistedInject
             import com.daugeldauge.kinzhal.annotations.Assisted
+            import com.daugeldauge.kinzhal.annotations.AssistedInject
             
             class TypeWithoutFactory @AssistedInject constructor(
                 @Assisted param1: Int,
                 param2: String
             )
+        """.trimIndent()))
+    }
+
+    @Test
+    fun `failed to match assisted factory with constructor`() {
+        expectError("Factory method in @AssistedFactory must have assisted parameters by same names, types and in the same order as @AssistedInject constructor", kotlin("source.kt", """
+            import com.daugeldauge.kinzhal.annotations.Assisted
+            import com.daugeldauge.kinzhal.annotations.AssistedFactory
+            import com.daugeldauge.kinzhal.annotations.AssistedInject
+            
+            class AssistedType @AssistedInject constructor(
+                @Assisted param1: Int,
+                @Assisted param2: Int,
+                param3: String
+            )
+            
+            @AssistedFactory
+            interface AssistedFactoryImpl {
+                fun build(param2: Int, param1: Int): AssistedType
+            }
         """.trimIndent()))
     }
 

--- a/sample/src/commonMain/kotlin/com/daugeldauge/kinzhal/sample/graph/ActivityEntities.kt
+++ b/sample/src/commonMain/kotlin/com/daugeldauge/kinzhal/sample/graph/ActivityEntities.kt
@@ -5,6 +5,7 @@ package com.daugeldauge.kinzhal.sample.graph
 import com.daugeldauge.kinzhal.annotations.Inject
 import com.daugeldauge.kinzhal.annotations.Scope
 import com.daugeldauge.kinzhal.sample.graph.network.DeezerApi
+import com.daugeldauge.kinzhal.sample.graph.network.DiscogsApi
 import com.daugeldauge.kinzhal.sample.graph.network.SpotifyApi
 
 @Scope
@@ -18,5 +19,6 @@ class ArtistsPresenter @Inject constructor(
     private val artistImagesStorage: ArtistImagesStorage,
     private val deezer: DeezerApi,
     private val spotify: SpotifyApi,
+    private val discogs: DiscogsApi,
     private val router: Router,
 )

--- a/sample/src/commonMain/kotlin/com/daugeldauge/kinzhal/sample/graph/network/NetworkEntities.kt
+++ b/sample/src/commonMain/kotlin/com/daugeldauge/kinzhal/sample/graph/network/NetworkEntities.kt
@@ -2,6 +2,9 @@
 
 package com.daugeldauge.kinzhal.sample.graph.network
 
+import com.daugeldauge.kinzhal.annotations.Assisted
+import com.daugeldauge.kinzhal.annotations.AssistedFactory
+import com.daugeldauge.kinzhal.annotations.AssistedInject
 import com.daugeldauge.kinzhal.annotations.Inject
 import com.daugeldauge.kinzhal.annotations.Scope
 
@@ -16,8 +19,17 @@ interface DeezerApi
 
 interface SpotifyApi
 
+interface DiscogsApi
+
 class LastFmKtorApi @Inject constructor(client: HttpClient) : LastFmApi
 
 class DeezerKtorApi @Inject constructor(client: HttpClient) : DeezerApi
 
 class SpotifyKtorApi @Inject constructor(client: HttpClient) : SpotifyApi
+
+class DiscogsKtorApi @AssistedInject constructor(client: HttpClient, @Assisted apiKey: String, @Assisted userAgent: String) : DiscogsApi
+
+@AssistedFactory
+interface DiscogsKtorApiFactory {
+    fun create(apiKey: String, userAgent: String): DiscogsKtorApi
+}

--- a/sample/src/commonMain/kotlin/com/daugeldauge/kinzhal/sample/graph/network/NetworkModule.kt
+++ b/sample/src/commonMain/kotlin/com/daugeldauge/kinzhal/sample/graph/network/NetworkModule.kt
@@ -9,6 +9,11 @@ interface NetworkModule {
         fun provideHttpClient(@Suppress("UNUSED_PARAMETER") listOfUnknown: List<*>) = HttpClient()
 
         fun provideListOfUnknown(): List<*> = listOf(1, 2, 3)
+
+        @HttpClientScope
+        fun provideDiscogsImpl(assistedFactory: DiscogsKtorApiFactory): DiscogsKtorApi {
+            return assistedFactory.create(apiKey = "123", userAgent = "Kinzhal")
+        }
     }
 
     fun bindLastFm(lastFmApi: LastFmKtorApi): LastFmApi
@@ -17,4 +22,5 @@ interface NetworkModule {
 
     fun bindDeezer(deezerApi: DeezerKtorApi): DeezerApi
 
+    fun bindDeezer(discogsKtorApi: DiscogsKtorApi): DiscogsApi
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,8 +13,10 @@ dependencyResolutionManagement {
             version("kotlin", kotlinVersion)
 
             val kspVersion = "$kotlinVersion-1.0.15"
+            val kotlinpoet = "1.13.1"
 
-            library("kotlinpoet", "com.squareup:kotlinpoet:1.9.0")
+            library("kotlinpoet", "com.squareup", "kotlinpoet").version(kotlinpoet)
+            library("kotlinpoet-ksp", "com.squareup", "kotlinpoet-ksp").version(kotlinpoet)
             library("compileTestingKsp", "com.github.tschuchortdev:kotlin-compile-testing-ksp:1.4.4")
 
             library("ksp-SymbolProcessingApi", "com.google.devtools.ksp", "symbol-processing-api").version(kspVersion)


### PR DESCRIPTION
Same semantics as in [Dagger 2](https://dagger.dev/dev-guide/assisted-injection.html) with minor changes:
- [Identifier parameter](https://github.com/google/dagger/blob/44d4f4b85fb1e39fb74398f509c2118c593faf9c/java/dagger/assisted/Assisted.java#L81) is not supported in `@Assisted` annotation since there is not problem in disambiguating parameters with the same type simply by name using KSP ([original Dagger 2 issue](https://github.com/google/dagger/issues/2281)).
- Assisted parameters matching between constructor and factory method  is stricter than in Dagger 2 – here parameter names also must be the same and in the same order

Closes #6